### PR TITLE
Fixed module declarations in relation with TypeScript React.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,11 +2,11 @@ import * as React from "react";
 
 export interface JoditProps {
     content: string;
-    onChange(value: string): void;
     config: any;
+    onChange(value: string): void;
 }
 
-export class JoditEditor extends React.Component<JoditProps, any> {
+export default class JoditEditor extends React.Component<JoditProps, any> {
     constructor(props: JoditProps, context: any);
     render(): JSX.Element;
 }

--- a/src/JoditEditor.d.ts
+++ b/src/JoditEditor.d.ts
@@ -1,11 +1,10 @@
 import React from 'react';
 
-declare module 'jodit-react' {
-    export interface IJoditEditorProps {
-        value: string,
-        config?: object,
-        onChange: (newValue: string) => void;
-    }
-    const JoditEditor: React.ComponentType<IJoditEditorProps>
-    export default JoditEditor;
+export interface IJoditEditorProps {
+    content: string;
+    config: object;
+    onChange: (newValue: string) => void;
 }
+
+declare const JoditEditor: React.ComponentType<IJoditEditorProps>
+export default JoditEditor;


### PR DESCRIPTION
Since tslint in React doesn't allow export assignments in module augmentations, slightly rearranged JoditEditor.d.ts to comply with tslint's default rules. In addition, cleaned up index.d.ts to [export a default export](https://github.com/jodit/jodit-react/issues/5) for use with TypeScript.

Also cleaned up tiny inconsistencies (i.e. replacing 'value' with 'content' in JoditEditor.d.ts)