### PR TITLE
Make Babel ignore node_modules.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "presets": ["env", "react"],
   "plugins": ["transform-class-properties"]
+   "ignore": ["node_modules"]
 }


### PR DESCRIPTION
Compile time divided by 4.5