### PR TITLE
Rewriting outdated code (Hooks) and onBlur support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "@types/react": "^16.8.7",
-    "jodit": "^3.2.44"
+    "jodit": "^3.2.55"
   },
   "peerDependencies": {
     "react": "~0.14 || ^15.0.0 || ^16.0.0",


### PR DESCRIPTION
Rewriting outdated code (wrong modification of the state) to hooks. Adding onBlur support to improve efficiency when editing larger documents.