### PR TITLE
Fix prop `config` type inference in TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export interface JoditProps {
     value: string;
     onChange?: (value: string) => void;
     onBlur?: (value: string) => void;
-    config: IJodit['options'];
+    config?: IJodit['options'];
 }
 
 export default class JoditEditor extends React.Component<JoditProps, any> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
+import { IJodit } from "jodit";
 
 export interface JoditProps {
     value: string;
     onChange?: (value: string) => void;
     onBlur?: (value: string) => void;
-    config: any;
+    config: IJodit['options'];
 }
 
 export default class JoditEditor extends React.Component<JoditProps, any> {

--- a/src/JoditEditor.d.ts
+++ b/src/JoditEditor.d.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
+import { IJodit } from 'jodit';
 
 declare module 'jodit-react' {
     export interface IJoditEditorProps {
         value: string,
-        config?: object,
+        config: IJodit['options'];
         onChange: (newValue: string) => void;
         onBlur: (newValue: string) => void;
     }
-    const JoditEditor: React.ComponentType<IJoditEditorProps>
+    const JoditEditor: React.ComponentType<IJoditEditorProps>;
     export default JoditEditor;
 }

--- a/src/JoditEditor.d.ts
+++ b/src/JoditEditor.d.ts
@@ -4,7 +4,7 @@ import { IJodit } from 'jodit';
 declare module 'jodit-react' {
     export interface IJoditEditorProps {
         value: string,
-        config: IJodit['options'];
+        config?: IJodit['options'];
         onChange: (newValue: string) => void;
         onBlur: (newValue: string) => void;
     }


### PR DESCRIPTION
## Fixed Jodit config type inference in TypeScript.

- fix: prop `config: any;` to `IJodit['options'];` (alias of class `Config`)
- fix: prop `config` to optional property

