### PR TITLE
Updating change event handling to make field more controlled.

### DIFF
--- a/examples/components/From.js
+++ b/examples/components/From.js
@@ -1,71 +1,75 @@
-import React, {Component} from 'react';
+import React, { useRef, useState } from 'react';
 
 import JoditEditor from "../../src/";
 
-export default class From extends Component {
-    state = {
-        config: {
-            readonly: false,
-            toolbar: true,
-        },
-        value: 'Test',
-        spin: 1
-    };
+const From = () => {
+    const [config, setConfig] = useState({
+        readonly: false,
+        toolbar: true,
+    })
 
-    toggleToolbar = () => {
-        this.setState(prevState => {
-            let config = {
-                readonly: prevState.config.readonly,
-                toolbar: !prevState.config.toolbar
-            };
+    const [textAreaValue, setTextAreaValue] = useState('Test')
 
-            return {
-                config: config,
-                value: prevState.value
-            }
-        });
-    };
+    const [inputValue, setInputValue] = useState('')
 
-    toggleReadOnly = () => {
-        this.setState(prevState => {
-            let config = {
-                toolbar: prevState.config.toolbar,
-                readonly: !prevState.config.readonly
-            };
+    const [spin, setSpin] = useState(1)
 
-            return {
-                config: config,
-                value: prevState.value
-            }
-        });
-    };
+    const toggleToolbar = () => (
+        setConfig(config => ({
+            ...config,
+            toolbar: !config.toolbar,
+        }))
+    )
 
-    onChangeInput = () => {
-        this.setState(prevState => ({
-            config: prevState.config,
-            value: this.refs.input.value
-        }));
-    };
+    const toggleReadOnly = () => (
+        setConfig(config => ({
+            ...config,
+            readonly: !config.readonly,
+        }))
+    )
 
-    spin = () => {
-        this.setState(prevState => ({
-            config: prevState.config,
-            value: prevState.value,
-            spin: prevState.spin + 1
-        }));
-    };
+    const handleTextAreaChange = newTextAreaValue => {
+        console.log('handleTextAreaChange', newTextAreaValue)
+        return (
+        setTextAreaValue(() => newTextAreaValue)
+    )}
 
-    render () {
-        return <div>
+    const handleInputChange = e => {
+        const { value } = e.target
+        setInputValue(() => value)
+        handleTextAreaChange(value)
+    }
+
+    const handleSpin = () => setSpin(spin => ++spin)
+
+    return (
+        <div>
             <JoditEditor
-                value={this.state.value}
-                config={this.state.config}
-                onChange={console.log}
-            />
-            <input placeholder={"entre some text"} ref="input" type="text" onChange={this.onChangeInput}/>
-            <button type="button" onClick={this.toggleReadOnly}>Toggle Read-Only</button>
-            <button type="button" onClick={this.toggleToolbar}>Toggle Toolbar</button>
-            <button type="button" onClick={this.spin}>Spin {this.state.spin}</button>
+                config={config}
+                onChange={handleTextAreaChange}
+                value={textAreaValue} />
+            <input
+                onChange={handleInputChange}
+                placeholder={"enter some text"}
+                type={"text"}
+                value={inputValue} />
+            <button
+                onClick={toggleReadOnly}
+                type={"button"}>
+                {'Toggle Read-Only'}
+            </button>
+            <button
+                onClick={toggleToolbar}
+                type={"button"}>
+                {'Toggle Toolbar'}
+            </button>
+            <button
+                type={"button"}
+                onClick={handleSpin}>
+                {`Spin ${spin}`}
+            </button>
         </div>
-    };
+    )
 }
+
+export default From

--- a/src/JoditEditor.js
+++ b/src/JoditEditor.js
@@ -1,59 +1,68 @@
-import React, {useEffect, useRef, forwardRef, useLayoutEffect} from 'react'
-import PropTypes from 'prop-types'
-import {Jodit} from 'jodit'
+import React, { useEffect, useRef, forwardRef, useLayoutEffect } from 'react'
+import { func, number, object, string } from 'prop-types'
+import { Jodit } from 'jodit'
 import 'jodit/build/jodit.min.css'
 
-const JoditEditor = forwardRef(({value, config, onChange, onBlur, tabIndex, name}, ref) => {
-	const textArea = useRef(null);
+const JoditEditor = forwardRef((props, ref) => {
+    const {
+        config,
+        id,
+        name,
+        onBlur,
+        onChange,
+        tabIndex,
+        value,
+    } = props
 
-	useLayoutEffect(() => {
-		if (ref) {
-			if (typeof ref === 'function') {
-				ref(textArea.current)
-			} else {
-				ref.current = textArea.current
-			}
-		}
-	}, [textArea]);
+    const textArea = useRef(null)
 
-	useEffect(() => {
-		const blurHandler = value => {
-			onBlur && onBlur(value)
-		};
+    useLayoutEffect(() => {
+        if (ref) {
+            if (typeof ref === 'function') {
+                ref(textArea.current)
+            } else {
+                ref.current = textArea.current
+            }
+        }
+    }, [textArea])
 
-		const changeHandler = value => {
-			onChange && onChange(value)
-		};
+    useEffect(() => {
+        const element = textArea.current
+        textArea.current = Jodit.make(element, config)
+        textArea.current.workplace.tabIndex = tabIndex || -1
 
-		const element = textArea.current;
-		textArea.current = Jodit.make(element, config);
+        // adding event handlers
+        textArea.current.events.on('blur', value => onBlur && onBlur(value))
+        textArea.current.events.on('change', value => onChange && onChange(value))
 
-		textArea.current.value = value;
-		textArea.current.events.on('blur', () => blurHandler(textArea.current.value));
-		textArea.current.events.on('change', () => changeHandler(textArea.current.value));
-		textArea.current.workplace.tabIndex = tabIndex || -1;
+        if (id) element.id = id
+        if (name) element.name = name
 
-		return () => {
-			textArea.current.destruct();
-      textArea.current = element;
-		}
-	}, [config]);
+        return () => {
+            textArea.current.destruct()
+            textArea.current = element
+        }
+    }, [config])
 
-	useEffect(() => {
-		if (textArea && textArea.current) {
-			textArea.current.value = value
-		}
-	}, [textArea, value]);
+    useEffect(() => {
+        if (textArea?.current?.value !== value) {
+            textArea.current.value = value
+        }
+    }, [value])
 
-	return <textarea ref={textArea} name={name}></textarea>
-});
+    return (
+        <textarea ref={textArea} />
+    )
+})
 
 JoditEditor.propTypes = {
-	value: PropTypes.string,
-	tabIndex: PropTypes.number,
-	config: PropTypes.object,
-	onChange: PropTypes.func,
-	onBlur: PropTypes.func
-};
+    config: object,
+    id: string,
+    name: string,
+    onBlur: func,
+    onChange: func,
+    tabIndex: number,
+    value: string,
+}
 
 export default JoditEditor


### PR DESCRIPTION
In this PR, I have updated the demo `Form` to use hooks and to pass down an onChange handler to the `JoditEditor`.

I have updated the `JoditEditor` so that it better handles tracking change event callbacks. This appears to also fix the issue where pasting a block of text causes the insert to be at the beginning of the textarea. This also appears to fix the jumping that can happen if you try to observe the previous iteration.

I have also added `id` and `name` props for testing and accessibility. 
 