### PR TITLE
Switched useEffect to useLayoutEffect

### DIFF
--- a/src/JoditEditor.js
+++ b/src/JoditEditor.js
@@ -16,7 +16,7 @@ const JoditEditor = forwardRef(({value, config, onChange, onBlur, tabIndex, name
 		}
 	}, [textArea]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const blurHandler = value => {
 			onBlur && onBlur(value)
 		};


### PR DESCRIPTION
I've noticed a brief flicker where the `<textarea />` shows as a normal textarea before it's turned into the Jodit editor.

Switching to useLayoutEffect ensures that `Jodit.make()` is called before the textarea is rendered.