### PR TITLE
fix: content clearing when swapping from html to rendered view

### DIFF
--- a/src/JoditEditor.js
+++ b/src/JoditEditor.js
@@ -50,7 +50,7 @@ const JoditEditor = forwardRef(({
 	}, [config])
 
 	useEffect(() => {
-		if (textArea?.current?.value !== value) {
+		if (textArea?.current?.value !== value && value !== '') {
 			textArea.current.value = value
 		}
 	}, [value])


### PR DESCRIPTION
When using the jodit-react demo, whenever I swap from html to rendered view, the content all disappears, as highlighted in [issue  121](https://github.com/jodit/jodit-react/issues/121). This small modification stops the app from clearing the content when the new content is blank.