### PR TITLE
Fix IJodit import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { IJodit } from "jodit";
+import { IJodit } from "jodit/types";
 
 export interface JoditProps {
 	value: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jodit-react",
-	"version": "1.2.10",
+	"version": "1.2.11",
 	"description": "Jodit is awesome and usefully wysiwyg editor with filebrowser",
 	"main": "build/jodit-react.js",
 	"author": "Chupurnov <chupurnov@gmail.com> (https://xdsoft.net/)s",


### PR DESCRIPTION
This PR updates the index.d.ts to import IJodit from `jodit/types` to fix this issue here:
https://github.com/jodit/jodit-react/issues/176

Since this project is using an old version of jodit 3.9.4, update Jodit
to export IJodit in the index would require updating the dependency
here.