### PR TITLE
remove type from import because it is causing Jodit' cannot be used a…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type { Jodit } from 'jodit/esm/index';
+import { Jodit } from 'jodit/esm/index';
 import * as React from 'react';
 
 type DeepPartial<T> = T extends object


### PR DESCRIPTION
…s a value because it was imported using 'import type' this error -[Done]

<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `main` branch
[ ] You've successfully run `npm test` locally
[ ] There are new or updated tests validating the change

-->

Fixes #
