### PR TITLE
Fix: Avoid "Abort async" error by utilizing waitForReady API in Jodit destruct handling

### DIFF
--- a/src/JoditEditor.tsx
+++ b/src/JoditEditor.tsx
@@ -70,8 +70,10 @@ const JoditEditor = forwardRef<IJodit, Props>(
 			}
 
 			return () => {
-				if (jodit) {
+				if (jodit.isReady) {
 					jodit.destruct();
+				} else {
+					jodit.waitForReady().then((joditInstance) => joditInstance.destruct());
 				}
 			};
 		}, [JoditConstructor, config, editorRef]);


### PR DESCRIPTION
## Description

This fix addresses a common issue in Next.js environments where directly calling `jodit.destruct()` results in an _"AbortError: Abort async"_ error. This occurs because the Jodit editor instance may not be fully initialized when `destruct()` is invoked.

## Problem Details

1. In a Next.js environment, invoking `jodit.destruct()` without checking readiness caused an Abort async error.
    > <img width="320px" alt="스크린샷 2025-01-15 오후 3 33 27" src="https://github.com/user-attachments/assets/8df3a3cd-baf5-4a27-a2b5-aa284018647b" />
3. An attempted workaround using `isReady` to ensure readiness mitigated the error but introduced a new issue—previous editor instances were not properly destructed, resulting in duplicate editor instances being created.
    > <img width="480px" alt="스크린샷 2025-01-16 오후 4 39 30" src="https://github.com/user-attachments/assets/24232cf2-e7a5-4630-bf6f-2e92d85bc530" />

## Solution

The solution utilizes the `jodit.waitForReady()` API provided by Jodit. This ensures that all asynchronous tasks associated with the editor instance are completed before calling `destruct()`. This approach eliminates both the "Abort async" error and the issue of duplicate editor instances.

## Changes Made

- Replaced `isReady`-based logic with `waitForReady` API to ensure proper handling of asynchronous tasks before destruction.
- Simplified the destruct logic for clarity and reliability.

## Impact

- Resolves _"Abort async"_ errors during destruction in Next.js environments.
- Prevents duplicate editor instances from being created.
- Improves stability and predictability in editor lifecycle management.

## Reference

[Jodit API Documentation - waitForReady](https://xdsoft.net/jodit/docs/classes/jodit.Jodit.html#waitforready)

---

Here's a checklist you might find useful.
- [x] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
- [x] Code is up-to-date with the `main` branch
- [ ] You've successfully run `npm test` locally
    I didn't found `test` npm script in `package.json` 😕: https://github.com/jodit/jodit-react/blob/16a9da9/package.json#L48-L60
- [ ] There are new or updated tests validating the change
