### PR TITLE
bugfix(291-chunk-load-error):import from jodit/es2021 instead

### DIFF
--- a/src/include.jodit.ts
+++ b/src/include.jodit.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - Jodit Editor (https://xdsoft.net/jodit/)
-import { Jodit as JoditES5 } from 'jodit/es5/jodit.fat.min';
+import { Jodit as JoditES5 } from 'jodit/es2021/jodit.fat.min';
 import type { Jodit as JoditConstructorType } from 'jodit';
 import 'jodit/es5/jodit.min.css';
 


### PR DESCRIPTION
Hi, this is a proposal bugfix for these issues:

[issue 291 chunk load errors in Next.js applications](https://github.com/jodit/jodit-react/issues/291)
[issue 289 same](https://github.com/jodit/jodit-react/issues/289)
[issue 288 same](https://github.com/jodit/jodit-react/issues/288)

importing from jodi/es5/jodi.fat.min.js is incompatible - causes parent applications to request '/build/164.fat.min.js' and '/build/5.fat.min.js' due to the webpack configuration in the es5 folder which will throw errors as well as Next.js redirecting to 404. 

Prevents use of the jodit-react in Next.js as disrupts development on watch and isn't deployable.

suggest replacing import with one of the others that is more compatible i.e. es2021 

All tests passed

Fixes #291 
