### PR TITLE
build(build-scripts):build improvements for improved compatibility #295

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@typescript-eslint/eslint-plugin": "^8.20.0",
+        "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",
         "eslint": "9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -4467,6 +4468,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
     "@typescript-eslint/eslint-plugin": "^8.20.0",
+    "cross-env": "^7.0.3",
     "css-loader": "^7.1.2",
     "eslint": "9.18.0",
     "eslint-config-prettier": "^10.0.1",
@@ -65,12 +66,13 @@
     "demo": "NODE_ENV=development node -r @swc-node/register ./node_modules/.bin/webpack serve --config ./examples/webpack.config.ts --mode development",
     "start": "npm run demo",
     "build": "npm run build:react && npm run build:types",
-    "build:react": "NODE_ENV=production node -r @swc-node/register ./node_modules/.bin/webpack --mode production",
+    "build:react": "cross-env NODE_ENV=production node -r @swc-node/register && npm run webpack",    
     "build:types": "rm -rf ./build/types && tsc --project tsconfig.types.json && npm run remove-css",
-    "remove-css": "replace \"import '[^']+.css';\" '' ./build/**/*.ts",
+    "remove-css": "replace \"import '[^']+.css';\" ''./build/**/*.ts",
     "github": "npm run git && git push --tags origin HEAD:main",
     "git": "git add --all  && git commit -m \"New version $npm_package_version. Read more https://github.com/jodit/jodit-react/releases/tag/$npm_package_version \" && git tag $npm_package_version",
-    "test": "jest"
+    "test": "jest",
+    "webpack": "webpack --config ./webpack.config.js --mode production"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -8,7 +8,8 @@
     "declarationDir": "./build/types",
     "module": "ES2022",
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "files": ["./src/index"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
-import path from 'path';
-import webpack from 'webpack';
-import process from 'process';
+const path = require('path');
+const webpack =require('webpack');
+const process =require('process');
 
-export default (env: unknown, argv: { mode?: string }, dir = process.cwd()) => {
+const config= (env, argv, dir = process.cwd()) => {
 	const debug = !argv || !argv.mode || !argv.mode.match(/production/);
 
 	return {
@@ -69,3 +69,4 @@ export default (env: unknown, argv: { mode?: string }, dir = process.cwd()) => {
 		}
 	};
 };
+module.exports = config;


### PR DESCRIPTION
Unable to run repo on a Windows or other OS.
[295 issue link](https://github.com/jodit/jodit-react/issues/295)

### Use Case for Proposal
I recently ran into an issue i wanted to take time to debug because i really wanted to use jodit in my Next.js project and i wanted to check if the demo could reproduce the same issue outside of Next or if it would be easier to debug with the repo locally - so this is why this is a problem if the repo cannot be run in different environments. These fixes allowed me to run and find the issue and open PR for it as well as these build fixes.

Opening this issue to link to PR.

The PR fixes 3 issues listed below with desscriptions of the type of errors they throw in another environment i.e. Windows
These issues prevent the contributor or user from running any of these scripts (or the demo ones but thats split out to a different PR)
`npm run build`
`npm run build:types` 
`npm run remove-css`

1. Using `NODE_ENV` instead of `cross-env NODE_ENV` is OS incompatible. cross-env makes it OS compatible which is good for a project that benefits from many contributors

> $ npm run build
> 
> > jodit-react@5.0.13 build
> > npm run build:react && npm run build:types
> 
> 
> > jodit-react@5.0.13 build:react
> > NODE_ENV=production node -r @swc-node/register ./node_modules/.bin/webpack --mode production
> 
> 'NODE_ENV' is not recognized as an internal or external command,
> operable program or batch file.
> 

2. Running `npm run build:types` broken
Threw an error due to issue with `remove-css` - this is a simple fix in package.json
Also could not build due to `"skipLibCheck": true` missing in tsconfig.types.json - threw errors about every .d.ts file, recommended to set to true so will be able to run build

> > > jodit-react@5.0.13 remove-css
> > replace "import '[^']+.css';" '' ./build/**/*.ts
> 
> node:fs:1633
>   const stats = binding.lstat(
>                         ^
> 
> Error: ENOENT: no such file or directory, lstat 'C:\Users\user\jodit-react\build\**\*.ts'
>     at Object.lstatSync (node:fs:1633:25)
>     at replacizeFileSync (C:\Users\user\jodit-react\node_modules\replace\replace.js:140:22)
>     at module.exports (C:\Users\user\jodit-react\node_modules\replace\replace.js:80:17)
>     at Object.<anonymous> (C:\Users\user\jodit-react\node_modules\replace\bin\replace.js:42:1)
>     at Module._compile (node:internal/modules/cjs/loader:1358:14)
>     at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
>     at Module.load (node:internal/modules/cjs/loader:1208:32)
>     at Module._load (node:internal/modules/cjs/loader:1024:12)
>     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
>     at node:internal/main/run_main_module:28:49 {
>   errno: -4058,
>   code: 'ENOENT',
>   syscall: 'lstat',
>   path: 'C:\\Users\\user\\jodit-react\\build\\**\\*.ts'
> }

3. Running `npm run build` broken (below)
This is what happens when using this `./node_modules/.bin/webpack` in Windows env (below)
Fixed by updating webpack.config to .js and package.json (adding webpack script that allows webpack to run correctly in any environment)
**This allows `npm run build:types` and `npm run build` runs successfully.**

> $ npm run build
> 
> > jodit-react@5.0.13 build
> > npm run build:react && npm run build:types
> 
> 
> > jodit-react@5.0.13 build:react
> > cross-env NODE_ENV=production node -r @swc-node/register ./node_modules/.bin/webpack --mode production      
> 
> C:\Users\user\jodit-react\node_modules\.bin\webpack:2
> basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
>           ^^^^^^^
> 
> SyntaxError: missing ) after argument list
>     at wrapSafe (node:internal/modules/cjs/loader:1281:20)
>     at Module._compile (node:internal/modules/cjs/loader:1321:27)
>     at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
>     at Object.newLoader [as .js] (C:\Users\user\jodit-react\node_modules\pirates\lib\index.js:121:7)
>     at Module.load (node:internal/modules/cjs/loader:1208:32)
>     at Function.Module._load (node:internal/modules/cjs/loader:1024:12)
>     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
>     at node:internal/main/run_main_module:28:49
> 
> Node.js v20.13.1



Fixes #295 
