### PR TITLE
fix: update smoke snapshots for current Jodit markup

### DIFF
--- a/tests/__snapshots__/smoke.test.tsx.snap
+++ b/tests/__snapshots__/smoke.test.tsx.snap
@@ -11,21 +11,30 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
       style="min-height: 200px; min-width: 200px; max-width: 100%; height: auto; --jd-jodit-workplace-height: auto; width: auto;"
     >
       <div
+        class="jodit-jodit__workplace-slot_above_true"
+        contenteditable="false"
+        data-jodit-above-toolbar=""
+      />
+      <div
         class="jodit-toolbar__box"
       >
         <div
           class="jodit-toolbar-editor-collection jodit-toolbar-editor-collection_mode_horizontal jodit-toolbar-editor-collection_size_middle"
+          role="toolbar"
         >
           <input
             disabled="true"
+            name="jodit-toolbar-focus-helper_[id]"
             style="width: 0; height:0; position: absolute; visibility: hidden;"
             tab-index="-1"
           />
           <div
             class="jodit-ui-group jodit-ui-group_line_true jodit-ui-group_size_middle"
+            role="group"
           >
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_font-style jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Bold"
@@ -36,6 +45,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Bold"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -72,6 +82,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Italic"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -108,6 +119,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Underline"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -144,6 +156,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Strike through"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -180,6 +193,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Clear Formatting"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -210,6 +224,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
             </div>
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_list jodit-ui-group_before-spacer_true jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Insert Unordered List"
@@ -220,6 +235,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Insert Unordered List"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -248,9 +264,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Insert Unordered List"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -274,6 +293,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Insert Ordered List"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -302,9 +322,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Insert Ordered List"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -325,9 +348,11 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
             />
             <div
               class="jodit-ui-group jodit-ui-group_size_middle"
+              role="list"
             />
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_font jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Font family"
@@ -338,6 +363,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Font family"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -365,9 +391,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Font family"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -391,6 +420,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Font size"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -418,9 +448,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Font size"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -444,6 +477,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Insert format block"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -469,9 +503,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Insert format block"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -495,6 +532,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Line height"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -538,9 +576,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Line height"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -558,6 +599,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
             </div>
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_color jodit-ui-group_before-spacer_true jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Fill color or set the text color"
@@ -568,6 +610,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Fill color or set the text color"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -595,9 +638,12 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Fill color or set the text color"
                   class="jodit-toolbar-button__trigger"
                   disabled="disabled"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -618,6 +664,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
             />
             <div
               class="jodit-ui-group jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Show all"
@@ -628,6 +675,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Show all"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   disabled="disabled"
@@ -747,6 +795,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
         >
           <div
             class="jodit-xpath"
+            role="list"
           >
             <span
               aria-label="Select all"
@@ -756,6 +805,7 @@ exports[`Smoke Test > Config > should render without crashing 1`] = `
               role="listitem"
             >
               <button
+                aria-label="Select all"
                 aria-pressed="false"
                 class="jodit-toolbar-button__button"
                 role="button"
@@ -842,21 +892,30 @@ exports[`Smoke Test > should render without crashing 1`] = `
       style="min-height: 200px; min-width: 200px; max-width: 100%; height: auto; --jd-jodit-workplace-height: auto; width: auto;"
     >
       <div
+        class="jodit-jodit__workplace-slot_above_true"
+        contenteditable="false"
+        data-jodit-above-toolbar=""
+      />
+      <div
         class="jodit-toolbar__box"
       >
         <div
           class="jodit-toolbar-editor-collection jodit-toolbar-editor-collection_mode_horizontal jodit-toolbar-editor-collection_size_middle"
+          role="toolbar"
         >
           <input
             disabled="true"
+            name="jodit-toolbar-focus-helper_[id]"
             style="width: 0; height:0; position: absolute; visibility: hidden;"
             tab-index="-1"
           />
           <div
             class="jodit-ui-group jodit-ui-group_line_true jodit-ui-group_size_middle"
+            role="group"
           >
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_font-style jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Bold"
@@ -866,6 +925,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Bold"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -900,6 +960,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Italic"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -934,6 +995,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Underline"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -968,6 +1030,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Strike through"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1002,6 +1065,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Clear Formatting"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1031,6 +1095,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
             </div>
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_list jodit-ui-group_before-spacer_true jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Insert Unordered List"
@@ -1040,6 +1105,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Insert Unordered List"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1067,8 +1133,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Insert Unordered List"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1091,6 +1160,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Insert Ordered List"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1118,8 +1188,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Insert Ordered List"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1140,9 +1213,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
             />
             <div
               class="jodit-ui-group jodit-ui-group_size_middle"
+              role="list"
             />
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_font jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Font family"
@@ -1152,6 +1227,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Font family"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1178,8 +1254,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Font family"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1202,6 +1281,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Font size"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1228,8 +1308,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Font size"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1252,6 +1335,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Insert format block"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1276,8 +1360,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Insert format block"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1300,6 +1387,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Line height"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1342,8 +1430,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Line height"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1361,6 +1452,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
             </div>
             <div
               class="jodit-ui-group jodit-ui-group_separated_true jodit-ui-group_group_color jodit-ui-group_before-spacer_true jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Fill color or set the text color"
@@ -1370,6 +1462,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Fill color or set the text color"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1396,8 +1489,11 @@ exports[`Smoke Test > should render without crashing 1`] = `
                   />
                 </button>
                 <span
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  aria-label="Fill color or set the text color"
                   class="jodit-toolbar-button__trigger"
-                  role="trigger"
+                  role="button"
                 >
                   <svg
                     viewBox="0 0 10 10"
@@ -1418,6 +1514,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
             />
             <div
               class="jodit-ui-group jodit-ui-group_size_middle"
+              role="list"
             >
               <span
                 aria-label="Show all"
@@ -1427,6 +1524,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
                 role="listitem"
               >
                 <button
+                  aria-label="Show all"
                   aria-pressed="false"
                   class="jodit-toolbar-button__button"
                   role="button"
@@ -1545,6 +1643,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
         >
           <div
             class="jodit-xpath"
+            role="list"
           >
             <span
               aria-label="Select all"
@@ -1554,6 +1653,7 @@ exports[`Smoke Test > should render without crashing 1`] = `
               role="listitem"
             >
               <button
+                aria-label="Select all"
                 aria-pressed="false"
                 class="jodit-toolbar-button__button"
                 role="button"

--- a/tests/smoke.test.tsx
+++ b/tests/smoke.test.tsx
@@ -4,6 +4,16 @@ import { describe, it, expect, vi } from 'vitest';
 import JoditEditor from '../src';
 import type { IJodit } from 'jodit/esm/types/jodit';
 
+function stabilizeFragment(fragment: DocumentFragment): DocumentFragment {
+	const clone = fragment.cloneNode(true) as DocumentFragment;
+	clone
+		.querySelectorAll('[name^="jodit-toolbar-focus-helper_"]')
+		.forEach(el => {
+			el.setAttribute('name', 'jodit-toolbar-focus-helper_[id]');
+		});
+	return clone;
+}
+
 describe('Smoke Test', () => {
 	it('should render without crashing', async () => {
 		const { asFragment, findByText } = render(
@@ -12,7 +22,7 @@ describe('Smoke Test', () => {
 		await act(async () => {});
 		const element = await findByText('Hello, world!');
 		expect(element).toBeTruthy();
-		expect(asFragment()).toMatchSnapshot();
+		expect(stabilizeFragment(asFragment())).toMatchSnapshot();
 	});
 
 	describe('Config', () => {
@@ -42,7 +52,7 @@ describe('Smoke Test', () => {
 			await editor!.waitForReady();
 			const element = await findByText('Hello, world!');
 			expect(element).toBeTruthy();
-			expect(asFragment()).toMatchSnapshot();
+			expect(stabilizeFragment(asFragment())).toMatchSnapshot();
 		});
 	});
 });


### PR DESCRIPTION
## Description

Smoke tests fail in CI because DOM snapshots are outdated after recent Jodit accessibility/markup changes. This has been failing since https://github.com/jodit/jodit-react/actions/runs/22232752786 and blocks the automatic release workflow (`test` → `build` → `publish`).

This PR:
- Updates smoke snapshots to match current `jodit@4.13.10` markup
- Normalizes the timestamped toolbar focus-helper `name` (`jodit-toolbar-focus-helper_<timestamp>`) before snapshotting so results stay deterministic across runs

cc @xdan

## Related Issue

Fixes #334

## Checklist
- [x] There is an associated issue labeled 'bug' or 'enhancement'
- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes locally
- [x] `npm run test` passes locally
- [x] New or updated tests validate the change (if applicable)

## Test plan
- [ ] Confirm CI Test job passes on this PR
- [ ] Confirm release workflow can proceed past the Test job after merge